### PR TITLE
Handle absent OpenAI API key gracefully

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,16 @@
 
 import streamlit as st
 import openai
+from key_utils import get_openai_api_key
 
 # 🔐 Secret Key Setup
-openai.api_key = st.secrets["OPENAI_API_KEY"]
+api_key = get_openai_api_key(getattr(st, "secrets", None))
+if api_key:
+    openai.api_key = api_key
+else:
+    st.error(
+        "OpenAI API key not provided. Set it via Streamlit secrets or the OPENAI_API_KEY environment variable."
+    )
 
 # UI Elements
 st.title("🧠 AI Radiology Optimizer")
@@ -19,7 +26,10 @@ fov = st.text_input("FOV", "220")
 issue = st.text_area("Scan issue (grainy, motion artifact, etc.)")
 
 if st.button("Get Suggestions"):
-    prompt = f"""Act as an MRI/CT scan optimization expert.
+    if not api_key:
+        st.error("OpenAI API key is required to fetch suggestions.")
+    else:
+        prompt = f"""Act as an MRI/CT scan optimization expert.
 Modality: {modality}
 Sequence: {sequence}
 TR: {tr}
@@ -30,9 +40,9 @@ Issue: {issue}
 
 Suggest 3 protocol changes to improve quality without increasing scan time.
 """
-    response = openai.ChatCompletion.create(
-        model="gpt-4",
-        messages=[{"role": "user", "content": prompt}]
-    )
-    st.write("### ✅ AI Optimization Suggestions")
-    st.write(response['choices'][0]['message']['content'])
+        response = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}]
+        )
+        st.write("### ✅ AI Optimization Suggestions")
+        st.write(response['choices'][0]['message']['content'])

--- a/key_utils.py
+++ b/key_utils.py
@@ -1,0 +1,13 @@
+import os
+
+
+def get_openai_api_key(secrets=None):
+    """Return OpenAI API key.
+
+    Tries to pull the key from provided Streamlit secrets dictionary. If the
+    key is not present, falls back to the ``OPENAI_API_KEY`` environment
+    variable. Returns ``None`` when no key is found.
+    """
+    if secrets and "OPENAI_API_KEY" in secrets:
+        return secrets["OPENAI_API_KEY"]
+    return os.getenv("OPENAI_API_KEY")

--- a/tests/test_key_utils.py
+++ b/tests/test_key_utils.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from key_utils import get_openai_api_key
+
+
+def test_returns_secret_when_available(monkeypatch):
+    secrets = {"OPENAI_API_KEY": "secret"}
+    monkeypatch.setenv("OPENAI_API_KEY", "env")
+    assert get_openai_api_key(secrets) == "secret"
+
+
+def test_falls_back_to_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "env")
+    assert get_openai_api_key() == "env"
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert get_openai_api_key() is None


### PR DESCRIPTION
## Summary
- prevent OpenAI calls when API key is missing and surface an error to the user
- allow `get_openai_api_key` to operate without a secrets object
- streamline tests for API key lookup behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88e30415c832ca736fd53123847ff