### PR TITLE
Add GitHub Actions workflow for automated tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow that runs on pushes to main/master and pull requests
- set up Python 3.11, install dependencies from requirements.txt, and execute pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68a88e305574832c9e4515ecbebab836